### PR TITLE
Fixed healthcheck discovery with dotted name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,12 @@ future releases, check `milestones`_ and :doc:`/about/vision`.
 0.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+Bugfixes.
+
+- Bug #52: fixed test discovery in packages and modules located outside working
+  directory. Was raising exceptions such as `AssertionError: Path must be
+  within the project` and `ValueError: Attempted relative import in
+  non-package`.
 
 
 0.6 (2014-03-07)

--- a/hospital/tests/loading.py
+++ b/hospital/tests/loading.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for :py:mod:`hospital.loading` module."""
+import os
 import unittest
 try:
     from unittest import mock
@@ -27,3 +28,29 @@ class HealthCheckLoaderTestCase(unittest.TestCase):
             def test_fake(self):
                 pass
         self.assertFalse(loader.is_healthcheck(FakeTestCase('test_fake')))
+
+    def test_discovery_by_python_path(self):
+        """HealthCheckLoader discovers healthchecks in Python packages."""
+        loader = HealthCheckLoader()
+        suite = loader.discover('hospital.healthchecks.predictable')
+        self.assertEqual(suite.countTestCases(), 1)
+
+    def test_discovery_of_module_by_python_path_in_stdlib(self):
+        """HealthCheckLoader can scan locations in stdlib."""
+        for location in ['datetime', 'xml']:  # A module and a package.
+            loader = HealthCheckLoader()
+            suite = loader.discover(location)
+            self.assertEqual(suite.countTestCases(), 0)
+
+    def test_discovery_of_module_by_python_path_outside_project(self):
+        """HealthCheckLoader can scan locations outside working directory."""
+        original_dir = os.getcwd()
+        try:
+            # Move to a place that is not parent of
+            # 'hospital.healthchecks.predictable'.
+            os.chdir(os.path.dirname(__file__))
+            loader = HealthCheckLoader()
+            suite = loader.discover('hospital')
+            self.assertTrue(suite.countTestCases() > 0)
+        finally:
+            os.chdir(original_dir)

--- a/hospital/utils/packaging.py
+++ b/hospital/utils/packaging.py
@@ -21,7 +21,7 @@ def get_metadata(distribution):
     ['BSD']
 
     """
-    raw_metadata = distribution.get_metadata(distribution.PKG_INFO)
+    raw_metadata = distribution.get_metadata('PKG-INFO')
     parsed_metadata = email.parser.Parser().parsestr(raw_metadata)
     metadata = {}
     for key, value in parsed_metadata.items():

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ KEYWORDS = [
 ]
 PACKAGES = [NAME.replace('-', '_')]
 REQUIREMENTS = [
-    'setuptools',
+    'setuptools>=0.7',
     'requests',
     'six',
 ]


### PR DESCRIPTION
Refs #52
Scanning packages and modules located outside working directory should be more robust.

Fixes `AssertionError: Path must be within the project` and `ValueError: Attempted relative import in non-package`.
