### PR TITLE
Reverted workaround for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ env:
 install:
   - pip install tox
 script:
-  - export PATH=/opt/python/2.7.6/bin:/opt/python/2.6.9/bin:/opt/python/3.4.0/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.2.1/bin:$PATH
   - tox

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,9 +13,6 @@ future releases, check `milestones`_ and :doc:`/about/vision`.
 - Refactoring #62: moved tests outside distribution, i.e. ``hospital.tests``
   is no longer available. Tests now live in hospital's repository only.
 
-- Bug #63: applied temporary workaround on Travis configuration.
-  See https://github.com/travis-ci/travis-ci/issues/2218.
-
 - Refactoring #59: removed nose and rednose from sphinx requirements in
   tox.ini.
 


### PR DESCRIPTION
Fix was published on travis-ci.org, so the workaround is no longer necessary.
Reverts c0319b1b4aabfc26d6baf6fa17424cfe2cf1855f, 2a6dfe97c62b332e9a9e5aa7b0f8ee604ea28c35 and a3a088d3f9a80f0f829ebd37c47cd7fba0294f01. Refs #63.
