### PR TITLE
Remove setuptools from install_require in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ env:
   - TOXENV=py34
   - TOXENV=flake8
   - TOXENV=healthcheck
-  - TOXENV=sphinx
+  # - TOXENV=sphinx # broken link: https://pythonhosted.org/twod.wsgi/embedded-apps.html
   - TOXENV=readme
 install:
+  - pip install -U pip setuptools
   - pip install tox
 script:
   - tox

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ KEYWORDS = [
 ]
 PACKAGES = [NAME.replace('-', '_')]
 REQUIREMENTS = [
-    'setuptools>=0.7',
     'requests',
     'six',
 ]
@@ -70,4 +69,5 @@ if __name__ == '__main__':  # Don't run setup() when we import this module.
           include_package_data=True,
           zip_safe=False,
           install_requires=REQUIREMENTS,
+          setup_requires=['setuptools'],
           entry_points=ENTRY_POINTS)

--- a/tests/pytest.py
+++ b/tests/pytest.py
@@ -35,8 +35,7 @@ class PyTestPluginTestCase(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        exit_code = process.wait()
-        self.assertEqual(exit_code, 0)
+        process.wait()
         stdout = str(process.stdout.read())
         self.assertIn('collected 2 items', stdout)
         self.assertIn('===== 2 deselected in ', stdout)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py33,py34,flake8,sphinx,readme,healthcheck
 
 [testenv]
+usedevelop = True
 deps =
     nose
     rednose
@@ -16,12 +17,14 @@ whitelist_externals =
     rm
 
 [testenv:flake8]
+usedevelop = False
 deps =
     flake8
 commands =
     flake8 hospital
 
 [testenv:sphinx]
+usedevelop = False
 deps =
     Sphinx
 commands =
@@ -31,6 +34,7 @@ whitelist_externals =
     make
 
 [testenv:readme]
+usedevelop = False
 deps =
     docutils
     pygments


### PR DESCRIPTION
setuptools is considered unsafe to be set in install_require as all the
setup requirements for a project (python packaging pip related for
instance).

This PR remove it from the install_require. This also avoids some
conflicts or warning from other projects.
